### PR TITLE
Docs example fix: return valid resolve response for all-users

### DIFF
--- a/docs-src/modules/ROOT/examples/com/wsscode/pathom/book/connect/mutation_join_globals.cljs
+++ b/docs-src/modules/ROOT/examples/com/wsscode/pathom/book/connect/mutation_join_globals.cljs
@@ -22,7 +22,7 @@
 
 (pc/defresolver all-users [{::keys [db]} _]
   {::pc/output [{:user/all [:user/id :user/name :user/email :user/created-at]}]}
-  (vals (get @db :users)))
+  {:user/all (vals (get @db :users))})
 
 (def app-registry [user-create user-data all-users])
 


### PR DESCRIPTION
Before this resolver would either result in a 'not-found' or 'invalid resolve response' exception. I caught this when going through the docs and not getting this to work.